### PR TITLE
Upgrade rb-fsevent to get past native extension build error

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -176,7 +176,7 @@ GEM
       thor (~> 0.14.6)
     rake (0.9.2.2)
     rb-appscript (0.6.1)
-    rb-fsevent (0.4.3.1)
+    rb-fsevent (0.9.2)
     rdoc (3.11)
       json (~> 1.4)
     rspec (2.6.0)


### PR DESCRIPTION
Fixed the following build error:

``` bash
Gem::Installer::ExtensionBuildError: ERROR: Failed to build gem native extension.

        /Users/Stephen/.rvm/rubies/ruby-1.9.3-p194/bin/ruby extconf.rb 
creating Makefile
extconf.rb:21:in '<main>': Only Darwin systems greater than 8 (Mac OS X 10.5+) are supported (RuntimeError)

Gem files will remain installed in /Users/Stephen/.rvm/gems/ruby-1.9.3-p194/gems/rb-fsevent-0.4.3.1 for inspection.
Results logged to /Users/Stephen/.rvm/gems/ruby-1.9.3-p194/gems/rb-fsevent-0.4.3.1/ext/gem_make.out
An error occurred while installing rb-fsevent (0.4.3.1), and Bundler cannot continue.
Make sure that `gem install rb-fsevent -v '0.4.3.1' succeeds before bundling.
```
